### PR TITLE
update example instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This package warns when defer is used within loops.
 ## Example
 
 ```bash
-$ go get github.com/eatonphil/deferlint
-$ go vet -vettool=/Users/philipeaton/go/bin/deferlint ./tests
+$ go install github.com/eatonphil/deferlint/cmd/deferlint
+$ go vet -vettool=$(which deferlint) ./tests
 # github.com/eatonphil/deferlint/tests
 tests/deferloop.go:7:3: defer in loop found "defer f()"
 ```


### PR DESCRIPTION
- `got get` does not install the binary
- get path to `deferlint` with `which`, should work with copy & paste on every unix system, user independet